### PR TITLE
change the base image from SL7 to fnal-wn-sl7

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM fermilab/fnal-wn-sl7
 
 RUN yum -y update && \
     yum -y install epel-release && \
-    yum -y install screen wget patch libtool git-all gcc gcc-c++ gcc-gfortran \
+    yum -y install wget patch libtool git-all gcc gcc-c++ gcc-gfortran \
            boost-devel python-devel cmake doxygen mariadb-devel sqlite-devel ncurses-devel \
            zlib-devel bzip2-devel freetype-devel pcre-devel xz-devel lz4-devel libX11-devel \
            libXpm-devel libXft-devel libXext-devel fftw-devel gsl-devel libxml2-devel \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,26 @@
-FROM scientificlinux/sl:7
+FROM fermilab/fnal-wn-sl7
 
 RUN yum -y update && \
     yum -y install epel-release && \
-    yum -y install sudo screen wget patch libtool git-all gcc gcc-c++ gcc-gfortran \
+    yum -y install screen wget patch libtool git-all gcc gcc-c++ gcc-gfortran \
            boost-devel python-devel cmake doxygen mariadb-devel sqlite-devel ncurses-devel \
            zlib-devel bzip2-devel freetype-devel pcre-devel xz-devel lz4-devel libX11-devel \
            libXpm-devel libXft-devel libXext-devel fftw-devel gsl-devel libxml2-devel \
            openssl-devel libXmu-devel xerces-c-devel mesa-libGL-devel mesa-libGLU-devel && \
     yum -y clean all && \
-    useradd -d /home/e1039 -G wheel -m -U -p $(openssl passwd -1 spinquest) e1039 && \
-    mkdir -p /opt/e1039/.downloads && chown -R e1039:e1039 /opt/e1039 && \
-    mkdir -p /var/e1039_install_cache && chown -R e1039:e1039 /var/e1039_install_cache
-COPY yum.conf /etc/yum.conf
-COPY sqsetup /usr/local/bin
-COPY install_cache/*             /var/e1039_install_cache/
+	mkdir /e906
+#    useradd -d /home/e1039 -G wheel -m -U -p $(openssl passwd -1 spinquest) e1039 && \
+#    mkdir -p /opt/e1039/.downloads && chown -R e1039:e1039 /opt/e1039 && \
+#    mkdir -p /var/e1039_install_cache && chown -R e1039:e1039 /var/e1039_install_cache
+#COPY yum.conf /etc/yum.conf
+#COPY sqsetup /usr/local/bin
+#COPY install_cache/*             /var/e1039_install_cache/
 
 
 # below should be done as normal user
-USER e1039
-WORKDIR /home/e1039
+#USER e1039
+#WORKDIR /home/e1039
 
-RUN cat /var/e1039_install_cache/bashrc_supplement >> /home/e1039/.bashrc
+#RUN cat /var/e1039_install_cache/bashrc_supplement >> /home/e1039/.bashrc
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Using fnal-wn-sl7 as base image ensure we have the access to pnfs, cvmfs and other fermilab resources 

remove sudo, as sudo will not work under singularity
comment out lines related to including e1039-share with the image
comment out lines related to creating a new user (this is ignored when converting to singularity)